### PR TITLE
Correct PowerShell False Positive Leak when passing variables to ConvertTo-SecureString

### DIFF
--- a/UDMSecretChecksv8.toml
+++ b/UDMSecretChecksv8.toml
@@ -184,7 +184,7 @@ regex = '''(private\sconst\sstring\sAccessTokenSecret|private\sconst\sstring\sac
 id = "CSCAN0220 1" 
 description = "DefaultPasswordContexts 1" 
 path = '''\.(?:ps1|psm1|)$'''
-regex = '''ConvertTo-SecureString(?:\s*-String)?\s*"[^"\r?\n]+"'''
+regex = '''ConvertTo-SecureString(?:\s*-String)?\s*"[^$"\r?\n]+"'''
 [rules.allowlist]
 regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
 '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']


### PR DESCRIPTION
Currently,  gives a false positive on the following situations.

``` powershell
ConvertTo-SecureString "$(RundeckProd.Password)"
ConvertTo-SecureString -String "$(RundeckProd.Password)"
ConvertTo-SecureString "$($RundeckProd.Password)"
ConvertTo-SecureString -String "$RundeckProd.Password"
```

This has been corrected by adding the $ in the ^ group and you can see the tests for this defined here.
https://regexr.com/6in7t

Let me know if there is anything else I need to do.